### PR TITLE
Add docker-compose support for local execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,5 @@ COPY --from=build-env /graphvega /graphvega
 
 WORKDIR /graphvega
 EXPOSE 3000
+EXPOSE 8000
 ENTRYPOINT ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To get GraphVega up and running on your local machine, follow these steps:
 4.  In the root directory  create a `.env` file and enter your API key as
     follows:
     
-    `TRADIER_API_KEY = YOUR_API_KEY_HERE`
+    `TRADIER_API_KEY=YOUR_API_KEY_HERE`
 
 5.  Run the application in either of two ways: Locally or via Docker (explained below):
 
@@ -80,6 +80,23 @@ Running:
 Stopping:
 
     $ docker stop graphvega
+
+### Docker-Compose
+
+Make sure to create the `.env` file from step 4 above before building the
+image, otherwise it won't be included.
+
+Running:
+
+    $ docker-compose up
+
+    or 
+
+    $ docker-compose run
+
+Stopping:
+
+    $ docker-compose down
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "2"
+services:
+  app:
+    build: .
+    ports:
+      - '3000:3000'
+    volumes:
+      - ./:/var/www      
+      - node_modules:/var/www/node_modules
+volumes:
+  node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build: .
     ports:
       - '3000:3000'
+      - '8000:8000'
     volumes:
       - ./:/var/www      
       - node_modules:/var/www/node_modules


### PR DESCRIPTION
## Summary
- Adds docker-compose support for local development / execution
- Adds instructions for usage
- Adds port `8000` used by server to `Dockerfile`

## Context
- Allows for easier startup compared to direct docker approach
- Allows for ease of adding new dependencies

## Testing Plan
- Pull branch and follow instructions in Readme. Note: `.env` has been updated to not include whitespace.