### PR TITLE
Correct eqeqeq warnings

### DIFF
--- a/src/components/chain/option.jsx
+++ b/src/components/chain/option.jsx
@@ -53,12 +53,12 @@ const Option = props => {
   // };
 
   const setBorder = idx => {
-    if(props.option.option_type==="put" && idx == props.layout.length-1) {
+    if(props.option.option_type==="put" && idx === props.layout.length-1) {
       const style = {};
       style.borderRight = props.option.strike > props.quote.last ? "6px solid #3f51b5":"";
       return style;
     }
-    else if (props.option.option_type==="call" && idx == 0){
+    else if (props.option.option_type==="call" && idx === 0){
       const style = {};
       style.borderLeft = props.option.strike < props.quote.last ? "10px solid #3f51b5":"";
       return style;
@@ -221,7 +221,7 @@ const Option = props => {
             color={setButtonColor()}
             variant="outlined"
             size="small"
-            disabled={quantity==0}
+            disabled={quantity===0}
             onClick={() => add()}
           >
             {quantity >= 0 ? "Buy" : "Sell"}

--- a/src/components/chain/optionChain.jsx
+++ b/src/components/chain/optionChain.jsx
@@ -272,7 +272,7 @@ class OptionChain extends Component {
                       &nbsp;expiry option chain (rounded to 2 places)</h6>
                   </center>
                   <GreeksChart
-                    data={this.state.greeksChart == "calls" ? 
+                    data={this.state.greeksChart === "calls" ? 
                       this.state.callGreeksData :
                       this.state.putGreeksData}
                   />


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

```
app_1  | [client] src/components/chain/option.jsx
app_1  | [client]   Line 56:48:   Expected '===' and instead saw '=='  eqeqeq
app_1  | [client]   Line 61:55:   Expected '===' and instead saw '=='  eqeqeq
app_1  | [client]   Line 224:31:  Expected '===' and instead saw '=='  eqeqeq
app_1  | [client] 
app_1  | [client] src/components/chain/optionChain.jsx
app_1  | [client]   Line 275:50:  Expected '===' and instead saw '=='  eqeqeq
```